### PR TITLE
GCal plugin: Pass extendedProperties along

### DIFF
--- a/plugins/gcal/GcalEventSource.ts
+++ b/plugins/gcal/GcalEventSource.ts
@@ -110,7 +110,8 @@ export default class GcalEventSource extends EventSource {
       end: item.end.dateTime || item.end.date, // same
       url: url,
       location: item.location,
-      description: item.description
+      description: item.description,
+      meta_data: item.extendedProperties.shared
     }
   }
 


### PR DESCRIPTION
# About Extended properties
Extended properties allow you to set some meta data on google calendar events. They are not visible but can be set through the Google API. This is often used for meta data, like a tag or category for your event. 

# Problem
It would be super nice to attach a class depending on an extended property, or influence how an event is rendered. However, the gcal plugin doesn't pass the properties along to the fullcalendar event.

# Solution
Just pass along the shared extende properties to the fullcalendar event. The fix is small yet does the trick.